### PR TITLE
Add hex value field + conversion utils.

### DIFF
--- a/src/components/StopEditor.tsx
+++ b/src/components/StopEditor.tsx
@@ -7,6 +7,7 @@ import {
   FormControl,
   FormLabel,
   Grid,
+  Input,
   NumberInput,
   NumberInputField,
   Slider,
@@ -16,7 +17,7 @@ import {
 import React from "react";
 import { ColorStop } from "../types";
 import * as culori from "culori";
-import { clamp, modifyHSL } from "../utils";
+import { clamp, modifyHSL, hexToColor, colorToHex } from "../utils";
 import ColorComponentSlider from "./ColorComponentSlider";
 import { useColorStopsAPI } from "../hooks/useColorStopsAPI";
 
@@ -28,7 +29,7 @@ const formatComponentHelp = (value: number) => {
   const intValue = Math.round(value * 255);
   return (
     <>
-      {value.toFixed(5)} ({intValue}, {intValue.toString(16)})
+      {value.toFixed(5)} ({intValue})
     </>
   );
 };
@@ -187,6 +188,32 @@ function StopEditor({ stop }: StopEditorProps) {
             max={1}
             trackColor={`hsl(0deg, 0%, ${(colorAsHsl.l * 100).toFixed(1)}%)`}
           />
+        </Box>
+      </Grid>
+      <Grid templateColumns="repeat(3, 1fr)" gap={6}>
+        <Box>
+        <FormLabel>Hex value</FormLabel>
+        <Input
+            maxW="5rem"
+            size="xs"
+            value={colorToHex(stop.color)}
+            onChange={
+              React.useCallback(ev => {
+                  const newStop = { ...stop };
+                  const newColor = hexToColor(ev.target.value);
+                  if (newColor !== null) {
+                    newStop.color = {
+                      ...newColor,
+                      a: stop.color.a,
+                    };
+                  }
+                  csApi.change(newStop);
+                },
+                [csApi, stop],
+              )
+            }
+          >
+          </Input>
         </Box>
       </Grid>
       <Divider py={4} />

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,3 +35,18 @@ export function modifyHSL(
 export function clamp(n: number, min: number = 0, max: number = 1): number {
   return Math.max(min, Math.min(max, n));
 }
+
+export function hexToColor(hex: string): Color | null {
+  var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result ? {
+    a: 1.0,
+    r: parseInt(result[1], 16) / 255.0,
+    g: parseInt(result[2], 16) / 255.0,
+    b: parseInt(result[3], 16) / 255.0
+  } : null;
+}
+
+export function colorToHex(c: Color): string {
+  const hex = (c: number) => Math.round(c * 255).toString(16).padStart(2, '0').toUpperCase();
+  return `#${hex(c.r)}${hex(c.g)}${hex(c.b)}`;
+}


### PR DESCRIPTION
It's nice to be able to copy-paste values such as `#07864B` so added a field for that. The component-wise hex view was just cruft after that so got rid of it. (Besides, colours in hex are seldom viewed component-wise.)